### PR TITLE
fix: move devnet mnemonics to env vars, change get-user-info to read-only

### DIFF
--- a/clarity/contracts/sbtc-vault.clar
+++ b/clarity/contracts/sbtc-vault.clar
@@ -54,10 +54,10 @@
   )
 )
 
-(define-public (get-user-info (account principal))
-  (ok {
+(define-read-only (get-user-info (account principal))
+  {
     balance: (get-balance account),
     deposit-block: (get-deposit-block account),
     total-deposits: (var-get total-deposits)
-  })
+  }
 )

--- a/front-end/.env.example
+++ b/front-end/.env.example
@@ -4,3 +4,12 @@ NEXT_PUBLIC_STACKS_NETWORK=devnet
 # Contract deployer addresses (set when deploying to testnet/mainnet)
 NEXT_PUBLIC_CONTRACT_DEPLOYER_TESTNET_ADDRESS=XXXX
 NEXT_PUBLIC_CONTRACT_DEPLOYER_MAINNET_ADDRESS=XXXX
+
+# Devnet wallet mnemonics (standard Stacks devnet wallets)
+# Copy this file to .env.local and fill in values for local development
+NEXT_PUBLIC_DEVNET_MNEMONIC_DEPLOYER=twice kind fence tip hidden tilt action fragile skin nothing glory cousin green tomorrow spring wrist shed math olympic multiply hip blue scout claw
+NEXT_PUBLIC_DEVNET_MNEMONIC_1=sell invite acquire kitten bamboo drastic jelly vivid peace spawn twice guilt pave pen trash pretty park cube fragile unaware remain midnight betray rebuild
+NEXT_PUBLIC_DEVNET_MNEMONIC_2=hold excess usual excess ring elephant install account glad dry fragile donkey gaze humble truck breeze nation gasp vacuum limb head keep delay hospital
+NEXT_PUBLIC_DEVNET_MNEMONIC_3=cycle puppy glare enroll cost improve round trend wrist mushroom scorpion tower claim oppose clever elephant dinosaur eight problem before frozen dune wagon high
+NEXT_PUBLIC_DEVNET_MNEMONIC_4=board list obtain sugar hour worth raven scout denial thunder horse logic fury scorpion fold genuine phrase wealth news aim below celery when cabin
+NEXT_PUBLIC_DEVNET_MNEMONIC_5=hurry aunt blame peanut heavy update captain human rice crime juice adult scale device promote vast project quiz unit note reform update climb purchase

--- a/front-end/src/lib/devnet-wallet-context.ts
+++ b/front-end/src/lib/devnet-wallet-context.ts
@@ -12,36 +12,38 @@ export interface DevnetWalletContextType {
   setCurrentWallet: (wallet: DevnetWallet) => void;
 }
 
+// Devnet wallet mnemonics loaded from environment variables.
+// These are standard Stacks devnet wallets — see .env.example for values.
 export const devnetWallets: DevnetWallet[] = [
-  { 
-    stxAddress: 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM', 
+  {
+    stxAddress: 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM',
     label: 'Deployer',
-    mnemonic: 'twice kind fence tip hidden tilt action fragile skin nothing glory cousin green tomorrow spring wrist shed math olympic multiply hip blue scout claw'
+    mnemonic: process.env.NEXT_PUBLIC_DEVNET_MNEMONIC_DEPLOYER ?? ''
   },
-  { 
-    stxAddress: 'ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5', 
+  {
+    stxAddress: 'ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5',
     label: 'Wallet 1',
-    mnemonic: 'sell invite acquire kitten bamboo drastic jelly vivid peace spawn twice guilt pave pen trash pretty park cube fragile unaware remain midnight betray rebuild'
+    mnemonic: process.env.NEXT_PUBLIC_DEVNET_MNEMONIC_1 ?? ''
   },
-  { 
-    stxAddress: 'ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG', 
+  {
+    stxAddress: 'ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG',
     label: 'Wallet 2',
-    mnemonic: 'hold excess usual excess ring elephant install account glad dry fragile donkey gaze humble truck breeze nation gasp vacuum limb head keep delay hospital'
+    mnemonic: process.env.NEXT_PUBLIC_DEVNET_MNEMONIC_2 ?? ''
   },
-  { 
-    stxAddress: 'ST2JHG361ZXG51QTKY2NQCVBPPRRE2KZB1HR05NNC', 
+  {
+    stxAddress: 'ST2JHG361ZXG51QTKY2NQCVBPPRRE2KZB1HR05NNC',
     label: 'Wallet 3',
-    mnemonic: 'cycle puppy glare enroll cost improve round trend wrist mushroom scorpion tower claim oppose clever elephant dinosaur eight problem before frozen dune wagon high'
+    mnemonic: process.env.NEXT_PUBLIC_DEVNET_MNEMONIC_3 ?? ''
   },
-  { 
-    stxAddress: 'ST2NEB84ASENDXKYGJPQW86YXQCEFEX2ZQPG87ND', 
+  {
+    stxAddress: 'ST2NEB84ASENDXKYGJPQW86YXQCEFEX2ZQPG87ND',
     label: 'Wallet 4',
-    mnemonic: 'board list obtain sugar hour worth raven scout denial thunder horse logic fury scorpion fold genuine phrase wealth news aim below celery when cabin'
+    mnemonic: process.env.NEXT_PUBLIC_DEVNET_MNEMONIC_4 ?? ''
   },
-  { 
-    stxAddress: 'ST2REHHS5J3CERCRBEPMGH7921Q6PYKAADT7JP2VB', 
+  {
+    stxAddress: 'ST2REHHS5J3CERCRBEPMGH7921Q6PYKAADT7JP2VB',
     label: 'Wallet 5',
-    mnemonic: 'hurry aunt blame peanut heavy update captain human rice crime juice adult scale device promote vast project quiz unit note reform update climb purchase'
+    mnemonic: process.env.NEXT_PUBLIC_DEVNET_MNEMONIC_5 ?? ''
   },
 ];
 


### PR DESCRIPTION
## Summary

- Move 6 hardcoded devnet wallet mnemonics from `devnet-wallet-context.ts` to `NEXT_PUBLIC_` env vars (loaded at build time)
- Add all mnemonic values to `.env.example` for easy local setup (copy to `.env.local`)
- Change `get-user-info` from `define-public` to `define-read-only` — it performs no state changes, callers shouldn't pay tx fees

Fixes #1, Fixes #2

## Test plan

- [ ] Copy `front-end/.env.example` to `front-end/.env.local`, verify devnet wallets load correctly
- [ ] Verify `get-user-info` works as a read-only call (no tx required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)